### PR TITLE
feat: add autostart feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ const { time, start, pause, reset, status } = useTimer({
 
 The configuration and all its parameters are optional.
 
-| Property     | Type     | Default value | Description                                                                            |
-| ------------ | -------- | ------------- | -------------------------------------------------------------------------------------- |
-| endTime      | number   | null          | The value for which timer stops                                                        |
-| initialTime  | number   | 0             | The starting value for the timer                                                       |
-| interval     | number   | 1000          | The interval in milliseconds                                                           |
-| onTimeOver   | function |               | Callback function that is called when time is over                                     |
-| onTimeUpdate | function |               | Callback function that is called when time is updated                                  |
-| shouldAutostart         | boolean   | false             | Pass true to start timer automatically   
-| step         | number   | 1             | The value to add to each increment / decrement                                         |
-| timerType    | string   | "INCREMENTAL" | The choice between a value that increases ("INCREMENTAL") or decreases ("DECREMENTAL") |
+| Property        | Type     | Default value | Description                                                                            |
+| --------------- | -------- | ------------- | -------------------------------------------------------------------------------------- |
+| endTime         | number   | null          | The value for which timer stops                                                        |
+| initialTime     | number   | 0             | The starting value for the timer                                                       |
+| interval        | number   | 1000          | The interval in milliseconds                                                           |
+| onTimeOver      | function |               | Callback function that is called when time is over                                     |
+| onTimeUpdate    | function |               | Callback function that is called when time is updated                                  |
+| shouldAutostart | boolean  | false         | Pass true to start timer automatically                                                 |
+| step            | number   | 1             | The value to add to each increment / decrement                                         |
+| timerType       | string   | "INCREMENTAL" | The choice between a value that increases ("INCREMENTAL") or decreases ("DECREMENTAL") |

--- a/README.md
+++ b/README.md
@@ -116,5 +116,6 @@ The configuration and all its parameters are optional.
 | interval     | number   | 1000          | The interval in milliseconds                                                           |
 | onTimeOver   | function |               | Callback function that is called when time is over                                     |
 | onTimeUpdate | function |               | Callback function that is called when time is updated                                  |
-| step         | number   | 1             | the value to add to each increment / decrement                                         |
-| timerType    | string   | "INCREMENTAL" | the choice between a value that increases ("INCREMENTAL") or decreases ("DECREMENTAL") |
+| shouldAutostart         | boolean   | false             | Pass true to start timer automatically   
+| step         | number   | 1             | The value to add to each increment / decrement                                         |
+| timerType    | string   | "INCREMENTAL" | The choice between a value that increases ("INCREMENTAL") or decreases ("DECREMENTAL") |

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type Config = {
   interval: number;
   onTimeOver?: () => void;
   onTimeUpdate?: (time: number) => void;
+  shouldAutostart: boolean;
   step: number;
   timerType: TimerType;
 };

--- a/src/useTimer.test.tsx
+++ b/src/useTimer.test.tsx
@@ -117,6 +117,26 @@ describe('Start', () => {
     // Then
     expect(getByTestId('time').textContent).toBe('5');
   });
+
+  it('should autostart', () => {
+    // Given
+    const Component = () => {
+      const { time } = useTimer({
+        shouldAutostart: true,
+      });
+
+      return <p data-testid="time">{time}</p>;
+    };
+
+    const { getByTestId } = render(<Component />);
+
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+
+    // Then
+    expect(getByTestId('time').textContent).toBe('20');
+  });
 });
 
 describe('Stop', () => {

--- a/src/useTimer.ts
+++ b/src/useTimer.ts
@@ -45,7 +45,7 @@ export const useTimer = ({
     if (shouldAutostart) {
       dispatch({ type: 'start' });
     }
-  }, []);
+  }, [shouldAutostart]);
 
   useEffect(() => {
     if (typeof onTimeUpdate === 'function') {

--- a/src/useTimer.ts
+++ b/src/useTimer.ts
@@ -10,6 +10,7 @@ export const useTimer = ({
   endTime,
   onTimeOver,
   onTimeUpdate,
+  shouldAutostart = false,
 }: Partial<Config> = {}): ReturnValue => {
   const [state, dispatch] = useReducer(reducer, {
     status: 'STOPPED',
@@ -39,6 +40,12 @@ export const useTimer = ({
 
     dispatch({ type: 'start' });
   }, [reset, isTimeOver]);
+
+  useEffect(() => {
+    if (shouldAutostart) {
+      dispatch({ type: 'start' });
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof onTimeUpdate === 'function') {


### PR DESCRIPTION
👉 The idea to add autostart comes from [this issue](https://github.com/thibaultboursier/use-timer/issues/47).

If consumer provides `shouldAutostart` parameter with `true` value, the timer will start automatically.