### PR TITLE
fix: resolve start function reference issue

### DIFF
--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -10,7 +10,8 @@ const RESET = (initialTime: number) =>
 
 const SET = (newTime: number) => createActionType('set', { newTime });
 
-const START = () => createActionType('start');
+const START = (initialTime: number) =>
+  createActionType('start', { initialTime });
 
 const STOP = () => createActionType('stop');
 

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,4 +1,3 @@
-import { act } from 'react-dom/test-utils';
 import { State } from '../types';
 import { TimerActionsType } from './actions';
 
@@ -25,7 +24,6 @@ function reducer(state: State, action: TimerActionsType): State {
       return {
         ...state,
         status: 'STOPPED',
-        isTimeOver: false,
         time: action.payload.initialTime,
       };
     }
@@ -36,16 +34,18 @@ function reducer(state: State, action: TimerActionsType): State {
       };
     }
     case 'start': {
+      const { initialTime } = action.payload;
+
       return {
         ...state,
         status: 'RUNNING',
+        time: state.status === 'STOPPED' ? initialTime : state.time,
       };
     }
     case 'stop': {
       return {
         ...state,
         status: 'STOPPED',
-        isTimeOver: true,
       };
     }
     default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,6 @@ export type ReturnValue = {
 
 export interface State {
   status: Status;
-  isTimeOver: boolean;
   time: number;
   timerType: TimerType;
 }

--- a/src/useTimer.ts
+++ b/src/useTimer.ts
@@ -13,12 +13,11 @@ export const useTimer = ({
 }: Partial<Config> = {}): ReturnValue => {
   const [state, dispatch] = useReducer(reducer, {
     status: 'STOPPED',
-    isTimeOver: false,
     time: initialTime,
     timerType,
   });
 
-  const { status, isTimeOver, time } = state;
+  const { status, time } = state;
 
   const advanceTime = useCallback((timeToAdd) => {
     dispatch({ type: 'advanceTime', payload: { timeToAdd } });
@@ -33,12 +32,8 @@ export const useTimer = ({
   }, [initialTime]);
 
   const start = useCallback(() => {
-    if (isTimeOver) {
-      reset();
-    }
-
-    dispatch({ type: 'start' });
-  }, [reset, isTimeOver]);
+    dispatch({ type: 'start', payload: { initialTime } });
+  }, []);
 
   useEffect(() => {
     if (typeof onTimeUpdate === 'function') {


### PR DESCRIPTION
## Issue (https://github.com/thibaultboursier/use-timer/issues/47)
Each time `isTimeOver` property changed, `start` function was re-created. So, for each consumer of `useTimer` library which used a `useEffect` hook with `start` function inside dependencies array, it caused a re-render.

## Fix
Now, `isTimeOver` property does not exist anymore. `start` function has no more dependencies, and only dispatch a `START` action. Inside `START` action reducer, if timer has `STOPPED` status, we simply reset time with initial time.