### PR TITLE
Issues caused by missing items in hook dependency arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-timer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/useTimer.test.tsx
+++ b/src/useTimer.test.tsx
@@ -61,6 +61,37 @@ describe('Start', () => {
     expect(getByTestId('time').textContent).toBe('15');
   });
 
+  it('should start timer on updated initialTime value', () => {
+    // Given
+    const Component = ({ initialTime }: { initialTime: number }) => {
+      const { time, start } = useTimer({
+        initialTime,
+      });
+
+      return (
+        <div>
+          <button onClick={start}>Start</button>
+          <p data-testid="time">{time}</p>
+        </div>
+      );
+    };
+
+    const { getByRole, getByTestId, rerender } = render(
+      <Component initialTime={10} />
+    );
+    rerender(<Component initialTime={20} />);
+
+    // When
+    fireEvent.click(getByRole('button'));
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    // Then
+    expect(getByTestId('time').textContent).toBe('25');
+  });
+
   it('should start decremental timer with an initial time of 100', () => {
     // Given
     const Component = () => {
@@ -626,5 +657,44 @@ describe('State and callbacks', () => {
     expect(onTimeUpdate).toHaveBeenCalledTimes(11);
     expect(onTimeUpdate).toHaveBeenNthCalledWith(5, 4);
     expect(onTimeUpdate).toHaveBeenLastCalledWith(10);
+  });
+
+  it('should call updated callback function when time is updated', () => {
+    // Given
+    const initialOnTimeUpdate = jest.fn();
+    const updatedOnTimeUpdate = jest.fn();
+    const Component = ({
+      onTimeUpdate,
+    }: {
+      onTimeUpdate: (time: number) => void;
+    }) => {
+      const { start } = useTimer({
+        endTime: 10,
+        initialTime: 0,
+        onTimeUpdate,
+      });
+
+      return (
+        <div>
+          <button onClick={start}>Start</button>
+        </div>
+      );
+    };
+
+    const { getByRole, rerender } = render(
+      <Component onTimeUpdate={initialOnTimeUpdate} />
+    );
+    rerender(<Component onTimeUpdate={updatedOnTimeUpdate} />);
+
+    // When
+    fireEvent.click(getByRole('button'));
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    // Then
+    expect(initialOnTimeUpdate).toHaveBeenCalledTimes(1);
+    expect(updatedOnTimeUpdate).toHaveBeenCalledTimes(11);
   });
 });

--- a/src/useTimer.test.tsx
+++ b/src/useTimer.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useTimer } from './useTimer';
 import { act } from 'react-dom/test-utils';
 import { render, fireEvent } from '@testing-library/react';
+import { Config } from './types';
 
 jest.useFakeTimers();
 
@@ -669,9 +670,7 @@ describe('State and callbacks', () => {
     // Given
     const initialOnTimeUpdate = jest.fn();
     const updatedOnTimeUpdate = jest.fn();
-    const Component: React.FC<Partial<Config>> = ({
-      onTimeUpdate,
-    }) => {
+    const Component: React.FC<Partial<Config>> = ({ onTimeUpdate }) => {
       const { start } = useTimer({
         endTime: 10,
         initialTime: 0,

--- a/src/useTimer.test.tsx
+++ b/src/useTimer.test.tsx
@@ -61,35 +61,41 @@ describe('Start', () => {
     expect(getByTestId('time').textContent).toBe('15');
   });
 
-  it('should start timer on updated initialTime value', () => {
+  it('should re-start timer with updated initialTime', () => {
     // Given
-    const Component = ({ initialTime }: { initialTime: number }) => {
-      const { time, start } = useTimer({
+    const Component: React.FC<Partial<Config>> = ({ initialTime }) => {
+      const { time, start, reset } = useTimer({
         initialTime,
       });
 
       return (
         <div>
-          <button onClick={start}>Start</button>
+          <button data-testid="start" onClick={start}>
+            Start
+          </button>
+          <button data-testid="reset" onClick={reset}>
+            Reset
+          </button>
           <p data-testid="time">{time}</p>
         </div>
       );
     };
 
-    const { getByRole, getByTestId, rerender } = render(
-      <Component initialTime={10} />
-    );
+    const { getByTestId, rerender } = render(<Component initialTime={10} />);
+    const startButton = getByTestId('start');
+    const resetButton = getByTestId('reset');
+
+    // When
+    fireEvent.click(startButton);
+
     rerender(<Component initialTime={20} />);
 
     // When
-    fireEvent.click(getByRole('button'));
-
-    act(() => {
-      jest.advanceTimersByTime(5000);
-    });
+    fireEvent.click(resetButton);
+    fireEvent.click(startButton);
 
     // Then
-    expect(getByTestId('time').textContent).toBe('25');
+    expect(getByTestId('time').textContent).toBe('20');
   });
 
   it('should start decremental timer with an initial time of 100', () => {
@@ -663,10 +669,8 @@ describe('State and callbacks', () => {
     // Given
     const initialOnTimeUpdate = jest.fn();
     const updatedOnTimeUpdate = jest.fn();
-    const Component = ({
+    const Component: React.FC<Partial<Config>> = ({
       onTimeUpdate,
-    }: {
-      onTimeUpdate: (time: number) => void;
     }) => {
       const { start } = useTimer({
         endTime: 10,

--- a/src/useTimer.ts
+++ b/src/useTimer.ts
@@ -34,19 +34,19 @@ export const useTimer = ({
 
   const start = useCallback(() => {
     dispatch({ type: 'start', payload: { initialTime } });
-  }, []);
+  }, [initialTime]);
 
   useEffect(() => {
     if (autostart) {
       dispatch({ type: 'start', payload: { initialTime } });
     }
-  }, [autostart]);
+  }, [autostart, initialTime]);
 
   useEffect(() => {
     if (typeof onTimeUpdate === 'function') {
       onTimeUpdate(time);
     }
-  }, [time]);
+  }, [time, onTimeUpdate]);
 
   useEffect(() => {
     if (status !== 'STOPPED' && time === endTime) {


### PR DESCRIPTION
Hi, I was running into this issue and found it's a simple fix. I was trying to restart a timer with a new initialTime and the timer would start with the old value instead. While implementing the fix I noticed the same issue with `onTimeUpdate`. Tests included.